### PR TITLE
Add caching for DFL queries

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,6 +46,8 @@ if "last_query_id" not in st.session_state:
 
 if "rag_cache" not in st.session_state:
     st.session_state.rag_cache = {}
+if "dfl_rag_cache" not in st.session_state:
+    st.session_state.dfl_rag_cache = {}
 
 # Generate session ID
 def generate_session_id():


### PR DESCRIPTION
- cache DFL embeddings in Streamlit session
- store/load cached DFL RAG responses
- include cached DFL responses in the prompt for the LLM
