### PR TITLE
Cache embeddings across calls

### DIFF
--- a/msme_bot.py
+++ b/msme_bot.py
@@ -64,6 +64,7 @@ def init_dfl_vector_store():
 llm = init_llm()
 scheme_vector_store = init_vector_store()
 dfl_vector_store = init_dfl_vector_store()
+embeddings = get_embeddings()
 
 # Dataclass to hold user context information
 @dataclass
@@ -206,7 +207,6 @@ def get_rag_response(query, vector_store, state = "ALL_STATES", gender=None, bus
             full_query = f"{query}. {' '.join(details)}"
 
         logger.debug(f"Processing query: {full_query}")
-        embeddings = get_embeddings()
         embed_start = time.time()
         query_embedding = embeddings.embed_query(full_query)
         logger.debug(f"Query embedding generated in {time.time() - embed_start:.2f} seconds (first 10 values): {query_embedding[:10]}")

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from functools import lru_cache
 from dotenv import load_dotenv
 from langchain_openai import OpenAIEmbeddings
 
@@ -10,6 +11,7 @@ logger = logging.getLogger(__name__)
 # Load environment variables
 load_dotenv()
 
+@lru_cache(maxsize=1)
 def get_embeddings():
     """
     Initialize and return the OpenAI embedding model.


### PR DESCRIPTION
- use `functools.lru_cache` for `utils.get_embeddings`
- fetch cached embeddings once in `msme_bot`
- remove redundant instantiation inside `get_rag_response`