### PR TITLE
Optimize conversation retrieval

### DIFF
--- a/app.py
+++ b/app.py
@@ -85,7 +85,7 @@ def restore_session_from_url():
                 }
                 st.session_state.page = "chat"
                 # Restore messages from MongoDB
-                conversations = data_manager.get_conversations(mobile_number)
+                conversations = data_manager.get_conversations(mobile_number, limit=10)
                 all_messages = []
                 for conv in conversations:
                     for msg in conv["messages"]:
@@ -293,7 +293,7 @@ def chat_page():
 
     # Trigger welcome message only for new users
     if not st.session_state.welcome_message_sent:
-        conversations = data_manager.get_conversations(st.session_state.user["mobile_number"])
+        conversations = data_manager.get_conversations(st.session_state.user["mobile_number"], limit=10)
         has_user_messages = False
         for conv in conversations:
             for msg in conv["messages"]:
@@ -328,7 +328,7 @@ def chat_page():
     all_messages = []
 
     # Fetch past conversations from MongoDB
-    conversations = data_manager.get_conversations(st.session_state.user["mobile_number"])
+    conversations = data_manager.get_conversations(st.session_state.user["mobile_number"], limit=10)
     for conv in conversations:
         for msg in conv["messages"]:
             if "content" not in msg or "role" not in msg or "timestamp" not in msg:

--- a/data.py
+++ b/data.py
@@ -362,14 +362,26 @@ class DataManager:
             logger.error(f"Unexpected error while saving conversation for session {session_id}: {str(e)}")
             raise
 
-    def get_conversations(self, mobile_number):
-        """Retrieve all conversations for a user, sorted by timestamp."""
+    def get_conversations(self, mobile_number, limit=None):
+        """Retrieve conversations for a user sorted by most recent first.
+
+        Parameters
+        ----------
+        mobile_number : str
+            The mobile number of the user.
+        limit : int, optional
+            Maximum number of conversations to return. If ``None`` all
+            conversations are returned.
+        """
         if not mobile_number or not isinstance(mobile_number, str):
             logger.error("Invalid mobile_number: mobile_number must be a non-empty string")
             raise ValueError("mobile_number must be a non-empty string")
 
         try:
-            conversations = list(self.db.conversations.find({"mobile_number": mobile_number}).sort("timestamp", 1))
+            cursor = self.db.conversations.find({"mobile_number": mobile_number}).sort("timestamp", -1)
+            if isinstance(limit, int) and limit > 0:
+                cursor = cursor.limit(limit)
+            conversations = list(cursor)
             if not conversations:
                 logger.warning(f"No conversations found for mobile_number {mobile_number}")
             else:

--- a/msme_bot.py
+++ b/msme_bot.py
@@ -420,7 +420,7 @@ def process_query(query, scheme_vector_store, dfl_vector_store, session_id, mobi
     logger.info(f"Using query language: {query_language}")
 
     # Check user type
-    conversations = data_manager.get_conversations(mobile_number)
+    conversations = data_manager.get_conversations(mobile_number, limit=10)
     has_user_messages = False
     for conv in conversations:
         for msg in conv["messages"]:
@@ -441,7 +441,7 @@ def process_query(query, scheme_vector_store, dfl_vector_store, session_id, mobi
             response = welcome_user(state_name, user_name, query_language)
             try:
                 interaction_id = generate_interaction_id(response, datetime.utcnow())
-                recent_conversations = data_manager.get_conversations(mobile_number)
+                recent_conversations = data_manager.get_conversations(mobile_number, limit=10)
                 if not any(
                     msg["role"] == "assistant" and msg["content"] == response
                     for conv in recent_conversations for msg in conv["messages"]
@@ -558,7 +558,7 @@ def process_query(query, scheme_vector_store, dfl_vector_store, session_id, mobi
     # Save conversation to MongoDB
     try:
         interaction_id = generate_interaction_id(query, datetime.utcnow())
-        recent_conversations = data_manager.get_conversations(mobile_number)
+        recent_conversations = data_manager.get_conversations(mobile_number, limit=10)
         messages_to_save = [
             {"role": "user", "content": query, "timestamp": datetime.utcnow(), "interaction_id": interaction_id},
             {"role": "assistant", "content": generated_response, "timestamp": datetime.utcnow(), "interaction_id": interaction_id},


### PR DESCRIPTION
## Summary
- add a `limit` parameter to `DataManager.get_conversations`
- fetch recent conversations only in `app.py` and `msme_bot.py`

## Testing
- `python -m py_compile app.py data.py msme_bot.py data_loader.py utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68512fbf90d8832e9c6d0c3bd36b984c