### PR TITLE
Add conversation summarization for contextual RAG

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,13 @@ import streamlit as st
 import random
 import string
 from datetime import datetime, timedelta
-from msme_bot import load_rag_data, load_dfl_data, process_query, welcome_user
+from msme_bot import (
+    load_rag_data,
+    load_dfl_data,
+    process_query,
+    welcome_user,
+    summarize_conversation,
+)
 from data import DataManager, STATE_MAPPING
 import numpy as np
 import logging
@@ -34,6 +40,8 @@ if "session_id" not in st.session_state:
 
 if "messages" not in st.session_state:
     st.session_state.messages = []
+if "conversation_summary" not in st.session_state:
+    st.session_state.conversation_summary = ""
 
 if "otp_generated" not in st.session_state:
     st.session_state.otp_generated = False
@@ -320,6 +328,7 @@ def chat_page():
                         "content": welcome_response,
                         "timestamp": datetime.utcnow()
                     })
+                    st.session_state.conversation_summary = summarize_conversation(st.session_state.messages)
                     logger.debug(f"Appended welcome message to session state: {welcome_response}")
             st.session_state.welcome_message_sent = True
 
@@ -392,6 +401,7 @@ def chat_page():
                     "content": response,
                     "timestamp": datetime.utcnow()
                 })
+                st.session_state.conversation_summary = summarize_conversation(st.session_state.messages)
                 with st.chat_message("assistant", avatar="logo.jpeg"):
                     st.markdown(f"{response} *({datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')})*")
                 logger.debug(f"Appended bot response to session state: {response} (Query ID: {query_id})")


### PR DESCRIPTION
## Summary
- add function to summarise recent conversation for context
- include conversation summary when retrieving RAG results
- update query processing to pass summary into retrieval
- keep conversation summary in session state for updates

## Testing
- `python -m py_compile app.py data.py data_loader.py msme_bot.py utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68514ba6f100832e91fbb9afa2a05005