### PR TITLE
Persist conversation summary across sessions

### DIFF
--- a/msme_bot.py
+++ b/msme_bot.py
@@ -611,7 +611,10 @@ def process_query(query, scheme_vector_store, dfl_vector_store, session_id, mobi
                     recent_query = st.session_state.messages[msg_index - 1]["content"]
                 break
 
-    conversation_history = build_conversation_history(st.session_state.messages)
+    conversation_history = st.session_state.get("conversation_history")
+    if not conversation_history:
+        conversation_history = build_conversation_history(st.session_state.messages)
+        st.session_state.conversation_history = conversation_history
     intent = classify_intent(query, recent_response or "", conversation_history)
     conversation_summary = st.session_state.get("conversation_summary", "")
     logger.info(f"Using conversation summary: {conversation_summary}")


### PR DESCRIPTION
## Summary
- retain conversation summary when restoring sessions
- build conversation summary at chat page load if missing
- persist conversation history across sessions by storing in session state

## Testing
- `python -m py_compile app.py msme_bot.py data.py data_loader.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68553cbf4ccc832ead6c52cd7d6c6179