### PR TITLE
Improve scheme follow-up handling

### DIFF
--- a/msme_bot.py
+++ b/msme_bot.py
@@ -821,6 +821,7 @@ def process_query(query, scheme_vector_store, dfl_vector_store, session_id, mobi
         "Confirmation_New_RAG",
     }:
         augmented_query = f"{last_scheme} {query}"
+        context_summary = f"Previous scheme mentioned: {last_scheme}"
     logger.info(f"Using conversation summary: {context_summary}")
     logger.info(f"Classified intent: {intent}")
 
@@ -914,7 +915,9 @@ def process_query(query, scheme_vector_store, dfl_vector_store, session_id, mobi
     if isinstance(rag_response, dict):
         if intent == "Specific_Scheme_Eligibility_Intent":
             scheme_guid = extract_scheme_guid(rag_response.get("sources", []))
-        scheme_name = extract_scheme_name(rag_response.get("sources", []))
+        scheme_name = extract_scheme_name(
+            rag_response.get("sources", []), scheme_guid
+        )
         if scheme_name:
             st.session_state.last_scheme_name = scheme_name
     generated_response = generate_response(

--- a/utils.py
+++ b/utils.py
@@ -48,14 +48,20 @@ def extract_scheme_guid(sources):
     return guid_counter.most_common(1)[0][0]
 
 
-def extract_scheme_name(sources):
-    """Return the most frequent non-empty scheme name from a list of documents."""
+def extract_scheme_name(sources, scheme_guid=None):
+    """Return the scheme name matching scheme_guid or the most frequent name."""
+    guid_to_name = {}
     name_counter = Counter()
     for doc in sources:
         if doc and getattr(doc, "metadata", None):
+            guid = doc.metadata.get("guid")
             name = doc.metadata.get("name")
+            if guid and name:
+                guid_to_name[str(guid).strip()] = str(name).strip()
             if name:
                 name_counter[str(name).strip()] += 1
+    if scheme_guid and guid_to_name.get(str(scheme_guid).strip()):
+        return guid_to_name[str(scheme_guid).strip()]
     if not name_counter:
         return None
     return name_counter.most_common(1)[0][0]


### PR DESCRIPTION
## Summary
- refine follow-up logic to keep context on the last mentioned scheme
- pick scheme name that matches the extracted GUID

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a73eb42d8832eb594c96b285523b1