### PR TITLE
Enhance scheme tracking

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -65,3 +65,16 @@ def extract_scheme_name(sources, scheme_guid=None):
     if not name_counter:
         return None
     return name_counter.most_common(1)[0][0]
+
+
+def extract_all_scheme_names(sources):
+    """Return a list of distinct scheme names from the documents."""
+    names = []
+    for doc in sources:
+        if doc and getattr(doc, "metadata", None):
+            name = doc.metadata.get("name")
+            if name:
+                name = str(name).strip()
+                if name and name not in names:
+                    names.append(name)
+    return names


### PR DESCRIPTION
## Summary
- expose all scheme names with new `extract_all_scheme_names`
- track recommended scheme names in session state
- set `last_scheme_name` based on user input or extracted data

## Testing
- `python -m py_compile msme_bot.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685a8ed70b80832e8ab3d9116b3a0192