### PR TITLE
Add audio player controls for voice notes

### DIFF
--- a/tts.py
+++ b/tts.py
@@ -44,9 +44,16 @@ def synthesize(text: str, language: str) -> bytes:
 
 def autoplay(audio_bytes: bytes) -> None:
     """Autoplay MP3 audio in Streamlit."""
+    audio_player(audio_bytes, autoplay=True)
+
+
+def audio_player(audio_bytes: bytes, autoplay: bool = False) -> None:
+    """Render an HTML audio player with optional autoplay."""
     b64 = base64.b64encode(audio_bytes).decode("utf-8")
+    autoplay_attr = "autoplay" if autoplay else ""
     audio_html = (
-        f'<audio autoplay="true" style="display:none">'
+        f'<audio {autoplay_attr} controls '
+        f'controlsList="nodownload noplaybackrate" style="width: 100%;">'
         f'<source src="data:audio/mp3;base64,{b64}" type="audio/mp3">'
         '</audio>'
     )


### PR DESCRIPTION
## Summary
- add audio_player utility to render HTML audio element
- display the audio player for the latest assistant response in chat
- autoplay most recent response using the new player

## Testing
- `python -m py_compile tts.py app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686371688a50832eb2cd7a3d3b5c71a6