### PR TITLE
Fix Pinecone search embedding call

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -75,7 +75,11 @@ class PineconeRecordRetriever(BaseRetriever):
             flt["applicability_state"] = {"$in": states}
 
         try:
-            embedding = pc.inference.embed(model="llama-text-embed-v2", inputs=query).data[0]["values"]
+            embedding = pc.inference.embed(
+                model="llama-text-embed-v2",
+                inputs=query,
+                parameters={"input_type": "search_query"},
+            ).data[0]["values"]
             res = self.index.query(vector=embedding, top_k=self.k, namespace="__default__", filter=flt, include_metadata=True)
         except Exception as e:
             logger.error(f"Pinecone search failed: {e}")


### PR DESCRIPTION
## Summary
- send `input_type` when embedding search queries for Pinecone

## Testing
- `python -m py_compile data_loader.py msme_bot.py utils.py data.py app.py tts.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc0dffdb4832ea8e6084dd1e37466