### PR TITLE
Add state filter for Pinecone search

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -84,11 +84,17 @@ class PineconeRecordRetriever(BaseRetriever):
                 parameters={"input_type": "query"},
             ).data[0]["values"]
             logger.debug(f"Query embedding sample: {embedding[:5]}")
+            filter_arg = None
+            if self.state:
+                filter_arg = {
+                    "applicability_state": {"$in": [self.state, "ALL_STATES"]}
+                }
             res = self.index.query(
                 vector=embedding,
                 top_k=self.k,
                 namespace="__default__",
                 include_metadata=True,
+                filter=filter_arg,
             )
         except Exception as e:
             logger.error(f"Pinecone search failed: {e}")


### PR DESCRIPTION
## Summary
- add metadata filter for user's state when querying Pinecone

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_686cecb66ad0832ebb90f5522d3907ad