### PR TITLE
Fix pinecone dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ tiktoken>=0.7.0
 openai>=1.0.0
 faiss-cpu>=1.8.0
 google-cloud-texttospeech
-pinecone-client
+pinecone>=7.0.0
 langchain-pinecone


### PR DESCRIPTION
## Summary
- fix vector store failure by requiring `pinecone` package instead of deprecated `pinecone-client`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d2809a9cc832eaafc8d8c84123c66