### PR TITLE
Add streaming LLM responses

### DIFF
--- a/app.py
+++ b/app.py
@@ -90,6 +90,17 @@ def type_text(text, placeholder, timestamp: Optional[str] = None, delay: float =
     final_text = typed if timestamp is None else f"{typed} *({timestamp})*"
     placeholder.markdown(final_text)
 
+
+def stream_tokens(token_generator, placeholder, timestamp: Optional[str] = None):
+    """Stream tokens from the LLM and display them as they arrive."""
+    typed = ""
+    for token in token_generator:
+        typed += token
+        placeholder.markdown(typed + "▌")
+    final_text = typed if timestamp is None else f"{typed} *({timestamp})*"
+    placeholder.markdown(final_text)
+    return typed
+
 # Restore session from URL query parameters
 def restore_session_from_url():
     query_params = st.query_params
@@ -327,35 +338,32 @@ def chat_page():
         user_type = "returning" if conversations else "new"
 
         if user_type == "new":
-            welcome_response, welcome_audio_task = process_query(
+            welcome_stream, welcome_audio_task = process_query(
                 "welcome",
                 st.session_state.scheme_vector_store,
                 st.session_state.dfl_vector_store,
                 st.session_state.session_id,
                 st.session_state.user["mobile_number"],
-                user_language=st.session_state.user["language"]
+                user_language=st.session_state.user["language"],
+                stream=True
             )
-            if welcome_response:  # Only append if a welcome message was generated
+            if welcome_stream:  # Only append if a welcome message was generated
                 with st.chat_message("assistant", avatar="logo.jpeg"):
                     message_placeholder = st.empty()
                     audio_placeholder = st.empty()
 
                     audio_container = {}
 
+                    welcome_timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
+                    final_welcome = stream_tokens(welcome_stream, message_placeholder, welcome_timestamp)
+
                     if welcome_audio_task:
                         def _gen_audio():
-                            script = welcome_audio_task()
+                            script = welcome_audio_task(final_welcome)
                             audio_container['data'] = synthesize(script, "Hindi")
 
                         audio_thread = threading.Thread(target=_gen_audio)
                         audio_thread.start()
-                    else:
-                        audio_thread = None
-
-                    welcome_timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
-                    type_text(welcome_response, message_placeholder, welcome_timestamp)
-
-                    if audio_thread:
                         audio_thread.join()
                         audio_player(audio_container['data'], autoplay=True, placeholder=audio_placeholder)
                 st.session_state.welcome_message_sent = True
@@ -426,13 +434,14 @@ def chat_page():
             # Display typing indicator while generating response
             with st.chat_message("assistant", avatar="logo.jpeg"):
                 with st.spinner("Assistant is typing..."):
-                    response, audio_task_for_tts = process_query(
+                    response_stream, audio_task_for_tts = process_query(
                         query,
                         st.session_state.scheme_vector_store,
                         st.session_state.dfl_vector_store,
                         st.session_state.session_id,
                         st.session_state.user["mobile_number"],
-                        user_language=st.session_state.user["language"]
+                        user_language=st.session_state.user["language"],
+                        stream=True
                     )
                 response_timestamp = datetime.utcnow()
 
@@ -440,34 +449,29 @@ def chat_page():
                 audio_placeholder = st.empty()
 
                 audio_container = {}
+                
+                display_timestamp_response = response_timestamp.strftime('%Y-%m-%d %H:%M:%S')
+
+                final_response = stream_tokens(response_stream, message_placeholder, display_timestamp_response)
 
                 if audio_task_for_tts:
                     def _gen_audio():
-                        script = audio_task_for_tts()
+                        script = audio_task_for_tts(final_response)
                         audio_container['data'] = synthesize(script, "Hindi")
 
                     audio_thread = threading.Thread(target=_gen_audio)
                     audio_thread.start()
-                else:
-                    audio_thread = None
-
-                full_content_response = response
-                display_timestamp_response = response_timestamp.strftime('%Y-%m-%d %H:%M:%S')
-
-                type_text(full_content_response, message_placeholder, display_timestamp_response)
-
-                if audio_thread:
                     audio_thread.join()
                     audio_player(audio_container['data'], autoplay=True, placeholder=audio_placeholder)
 
             last_msg = st.session_state.messages[-1] if st.session_state.messages else None
-            if not last_msg or not (last_msg["role"] == "assistant" and last_msg["content"] == response):
+            if not last_msg or not (last_msg["role"] == "assistant" and last_msg["content"] == final_response):
                 st.session_state.messages.append({
                     "role": "assistant",
-                    "content": response,
+                    "content": final_response,
                     "timestamp": response_timestamp,
                 })
-                logger.debug(f"Appended bot response to session state: {response} (Query ID: {query_id})")
+                logger.debug(f"Appended bot response to session state: {final_response} (Query ID: {query_id})")
                 logger.debug("Bot response appended")
 
 # Main app logic

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import streamlit as st
 import random
 import string
 import threading
+from streamlit.runtime.scriptrunner import add_script_run_ctx
 import time
 from datetime import datetime, timedelta
 from msme_bot import (
@@ -363,6 +364,7 @@ def chat_page():
                             audio_container['data'] = synthesize(script, "Hindi")
 
                         audio_thread = threading.Thread(target=_gen_audio)
+                        add_script_run_ctx(audio_thread)
                         audio_thread.start()
                         audio_thread.join()
                         audio_player(audio_container['data'], autoplay=True, placeholder=audio_placeholder)
@@ -460,6 +462,7 @@ def chat_page():
                         audio_container['data'] = synthesize(script, "Hindi")
 
                     audio_thread = threading.Thread(target=_gen_audio)
+                    add_script_run_ctx(audio_thread)
                     audio_thread.start()
                     audio_thread.join()
                     audio_player(audio_container['data'], autoplay=True, placeholder=audio_placeholder)

--- a/msme_bot.py
+++ b/msme_bot.py
@@ -1218,6 +1218,10 @@ def process_query(query, scheme_vector_store, dfl_vector_store, session_id, mobi
             logger.info(f"Maintaining stored scheme names: {st.session_state.scheme_names_str}")
 
     def audio_task(final_text=None):
+        if "scheme_names" not in st.session_state:
+            st.session_state.scheme_names = []
+        if "scheme_names_str" not in st.session_state:
+            st.session_state.scheme_names_str = ""
         text_for_use = final_text if stream else generated_response
         step_local = time.time()
         hindi_audio_script = generate_hindi_audio_script(

--- a/msme_bot.py
+++ b/msme_bot.py
@@ -36,7 +36,7 @@ def init_llm():
     if not api_key:
         raise ValueError("OPENAI_API_KEY environment variable not set")
     llm = ChatOpenAI(
-        model="gpt-4.1-nano",
+        model="gpt-4.1-mini-2025-04-14",
         api_key=api_key,
         base_url="https://api.openai.com/v1",
         temperature=0
@@ -367,15 +367,15 @@ def classify_intent(query, prev_response, conversation_history=""):
 
     **Instructions**:
     Return only one label from the following:
-       - Schemes_Know_Intent (e.g., 'Schemes for credit?', 'MSME ke liye schemes kya hain?', 'क्रेडिट के लिए योजनाएं?', 'loan chahiye', 'scheme dikhao')
-       - DFL_Intent (digital/financial literacy queries, e.g., 'How to use UPI?', 'डिजिटल भुगतान कैसे करें?', 'Opening Bank Account', 'Why get Insurance', 'Why take loans', 'Online Safety', 'How can going digital help grow business', etc.)
-       - Specific_Scheme_Know_Intent (e.g., 'What is FSSAI?', 'PMFME ke baare mein batao', 'एफएसएसएआई क्या है?', 'Pashu Kisan Credit Scheme ke baare mein bataiye', 'Udyam', 'Mudra Yojana')
-       - Specific_Scheme_Apply_Intent (e.g., 'Apply', 'Apply kaise karna hai', 'How to apply for FSSAI?', 'FSSAI kaise apply karu?', 'एफएसएसएआई के लिए आवेदन कैसे करें?')
-       - Specific_Scheme_Eligibility_Intent (e.g., 'Eligibility', 'Eligibility batao', 'Am I eligible for FSSAI?', 'FSSAI eligibility?', 'एफएसएसएआई की पात्रता क्या है?')
-       - Out_of_Scope (e.g., 'What's the weather?', 'Namaste', 'मौसम कैसा है?', 'Time?')
-       - Contextual_Follow_Up (e.g., 'Tell me more', 'Aur batao', 'और बताएं', 'iske baare mein aur jaankaari chahiye')
-       - Confirmation_New_RAG (Only to be chosen when user query is confirmation for initating another RAG search ("Yes", "Haan batao", "Haan dikhao", "Yes search again") AND previous assistant response says that the bot needs to fetch more details about some scheme. ('I need to fetch more details about [scheme name]. Please confirm if this is the scheme you meant.')
-       - Gratitude_Intent (user expresses thanks or acknowledgement, e.g., 'ok thanks', 'got it', 'theek hai', 'accha', 'thank you', 'शुक्रिया', 'धन्यवाद')
+       - Schemes_Know_Intent - General ambiguous queries enquiring about schemes or loans without specifics (e.g., 'loan', 'Schemes for credit?', 'MSME ke liye schemes kya hain?', 'क्रेडिट के लिए योजनाएं?', 'loan chahiye', 'scheme dikhao')
+       - DFL_Intent - Digital/financial literacy queries (e.g., 'Current account', 'How to use UPI?', 'डिजिटल भुगतान कैसे करें?', 'Opening Bank Account', 'Why get Insurance', 'Why take loans', 'Online Safety')
+       - Specific_Scheme_Know_Intent - Queries about specific schemes (e.g., 'What is FSSAI?', 'PMFME ke baare mein batao', 'एफएसएसएआई क्या है?', 'Pashu Kisan Credit Scheme ke baare mein bataiye', 'Udyam', 'Mudra Yojana', 'pmegp')
+       - Specific_Scheme_Apply_Intent - Queries about applying for specific schemes (e.g., 'Apply', 'Apply kaise karna hai', 'How to apply for FSSAI?', 'FSSAI kaise apply karu?', 'एफएसएसआईएआई के लिए आवेदन कैसे करें?')
+       - Specific_Scheme_Eligibility_Intent - Queries about eligibility for specific schemes (e.g., 'Eligibility', 'Eligibility batao', 'Am I eligible for FSSAI?', 'FSSAI eligibility?', 'एफएसएसआईएआई की पात्रता क्या है?')
+       - Out_of_Scope - Queries that are not relevant (e.g., 'What's the weather?', 'Namaste', 'मौसम कैसा है?', 'Time?')
+       - Contextual_Follow_Up - Follow-up queries (e.g., 'Tell me more', 'Aur batao', 'और बताएं', 'iske baare mein aur jaankaari chahiye')
+       - Confirmation_New_RAG - Confirmation for initiating another RAG search (Only to be chosen when user query is confirmation for initating another RAG search ("Yes", "Haan batao", "Haan dikhao", "Yes search again") AND previous assistant response says that the bot needs to fetch more details about some scheme. ('I need to fetch more details about [scheme name]. Please confirm if this is the scheme you meant.'))
+       - Gratitude_Intent - User expresses thanks or acknowledgement (e.g., 'ok thanks', 'got it', 'theek hai', 'accha', 'thank you', 'शुक्रिया', 'धन्यवाद')
 
     **Tips**:
        - Use rule-based checks for Out_of_Scope (keywords: 'hello', 'hi', 'hey', 'weather', 'time', 'namaste', 'mausam', 'samay').

--- a/msme_bot.py
+++ b/msme_bot.py
@@ -391,7 +391,7 @@ def classify_intent(query, prev_response, conversation_history=""):
         return "Out_of_Scope"
 
 # Generate final response based on intent and RAG output
-def generate_response(intent, rag_response, user_info, language, context, query, scheme_guid=None, scheme_details=None):
+def generate_response(intent, rag_response, user_info, language, context, query, scheme_guid=None, scheme_details=None, stream: bool = False):
     if intent == "Out_of_Scope":
         if language == "Hindi":
             return "क्षमा करें, मैं केवल सरकारी योजनाओं, डिजिटल या वित्तीय साक्षरता और व्यावसायिक वृद्धि पर मदद कर सकता हूँ।"
@@ -544,13 +544,34 @@ def generate_response(intent, rag_response, user_info, language, context, query,
     prompt = f"{base_prompt}{intent_prompt}\n{output_prompt}"
 
     try:
-        response = llm.invoke([{"role": "user", "content": prompt}])
-        final_text = response.content.strip()
-        if intent == "Specific_Scheme_Eligibility_Intent" and scheme_guid:
-            screening_link = f"https://customer.haqdarshak.com/check-eligibility/{scheme_guid}"
-            if screening_link not in final_text:
-                final_text += f"\n{screening_link}"
-        return final_text
+        if stream:
+            def token_generator():
+                buffer = ""
+                try:
+                    for chunk in llm.stream([{"role": "user", "content": prompt}]):
+                        token = chunk.content or ""
+                        buffer += token
+                        if token:
+                            yield token
+                except Exception as e:
+                    logger.error(f"Failed to stream response: {str(e)}")
+                    return
+
+                if intent == "Specific_Scheme_Eligibility_Intent" and scheme_guid:
+                    screening_link = f"https://customer.haqdarshak.com/check-eligibility/{scheme_guid}"
+                    if screening_link not in buffer:
+                        for char in "\n" + screening_link:
+                            yield char
+
+            return token_generator()
+        else:
+            response = llm.invoke([{"role": "user", "content": prompt}])
+            final_text = response.content.strip()
+            if intent == "Specific_Scheme_Eligibility_Intent" and scheme_guid:
+                screening_link = f"https://customer.haqdarshak.com/check-eligibility/{scheme_guid}"
+                if screening_link not in final_text:
+                    final_text += f"\n{screening_link}"
+            return final_text
     except Exception as e:
         logger.error(f"Failed to generate response: {str(e)}")
         if language == "Hindi":
@@ -836,7 +857,7 @@ def generate_hindi_audio_script(
             return "ऑडियो स्क्रिप्ट उत्पन्न करने में त्रुटि हुई है।" # Error generating audio script.
 
 # Main function to process query
-def process_query(query, scheme_vector_store, dfl_vector_store, session_id, mobile_number, user_language=None):
+def process_query(query, scheme_vector_store, dfl_vector_store, session_id, mobile_number, user_language=None, stream: bool = False):
     start_time = time.time()
     timings = {}
 
@@ -894,7 +915,7 @@ def process_query(query, scheme_vector_store, dfl_vector_store, session_id, mobi
         record("scheme_flow", step)
         generated_response = resp
 
-        def audio_task():
+        def audio_task(final_text=None):
             step_local = time.time()
             hindi_audio_script = generate_hindi_audio_script(
                 generated_response,
@@ -922,6 +943,11 @@ def process_query(query, scheme_vector_store, dfl_vector_store, session_id, mobi
             log_timings()
             return hindi_audio_script
 
+        if stream:
+            def gen():
+                for ch in generated_response:
+                    yield ch
+            return gen(), audio_task
         return generated_response, audio_task
 
 
@@ -930,7 +956,7 @@ def process_query(query, scheme_vector_store, dfl_vector_store, session_id, mobi
         if user_type == "new":
             response = welcome_user(state_name, user_name, query_language)
 
-            def audio_task():
+            def audio_task(final_text=None):
                 step_local = time.time()
                 hindi_audio_script = generate_hindi_audio_script(
                     response,
@@ -960,6 +986,11 @@ def process_query(query, scheme_vector_store, dfl_vector_store, session_id, mobi
                 return hindi_audio_script
 
             logger.info(f"Generated welcome response for new user in {time.time() - start_time:.2f} seconds: {response}")
+            if stream:
+                def gen():
+                    for ch in response:
+                        yield ch
+                return gen(), audio_task
             return response, audio_task
         else:
             logger.info(f"No welcome message for returning user")
@@ -1064,7 +1095,7 @@ def process_query(query, scheme_vector_store, dfl_vector_store, session_id, mobi
         else:
             first_q = ask_scheme_question("turnover", query_language)
 
-        def audio_task():
+        def audio_task(final_text=None):
             step_local = time.time()
             hindi_audio_script = generate_hindi_audio_script(
                 first_q,
@@ -1158,7 +1189,7 @@ def process_query(query, scheme_vector_store, dfl_vector_store, session_id, mobi
     if isinstance(rag_response, dict) and intent == "Specific_Scheme_Eligibility_Intent":
         scheme_guid = extract_scheme_guid(rag_response.get("sources", []))
     step = time.time()
-    generated_response = generate_response(
+    gen_result = generate_response(
         intent,
         rag_text or "",
         user_info,
@@ -1167,35 +1198,53 @@ def process_query(query, scheme_vector_store, dfl_vector_store, session_id, mobi
         query,
         scheme_guid=scheme_guid,
         scheme_details=st.session_state.scheme_flow_data if st.session_state.get("scheme_flow_data") else None,
+        stream=stream,
     )
     record("generate_response", step)
 
-    if intent == "Schemes_Know_Intent":
-        names = extract_scheme_names(generated_response)
-        if names:
-            st.session_state.scheme_names = [n for n in names]
-            st.session_state.scheme_names_str = " ".join([f"{i+1}. {n}" for i, n in enumerate(names, 1)])
-            logger.info(f"Stored scheme names from response: {st.session_state.scheme_names_str}")
-    elif intent in {"Specific_Scheme_Know_Intent", "Specific_Scheme_Apply_Intent", "Specific_Scheme_Eligibility_Intent","Contextual_Follow_Up","Confirmation_New_RAG"} and referenced_scheme:
-        if referenced_scheme not in st.session_state.scheme_names:
-            st.session_state.scheme_names = [referenced_scheme]
-            st.session_state.scheme_names_str = f"1. {referenced_scheme}"
-        logger.info(f"Maintaining stored scheme names: {st.session_state.scheme_names_str}")
+    if not stream:
+        generated_response = gen_result
 
-    def audio_task():
+        if intent == "Schemes_Know_Intent":
+            names = extract_scheme_names(generated_response)
+            if names:
+                st.session_state.scheme_names = [n for n in names]
+                st.session_state.scheme_names_str = " ".join([f"{i+1}. {n}" for i, n in enumerate(names, 1)])
+                logger.info(f"Stored scheme names from response: {st.session_state.scheme_names_str}")
+        elif intent in {"Specific_Scheme_Know_Intent", "Specific_Scheme_Apply_Intent", "Specific_Scheme_Eligibility_Intent","Contextual_Follow_Up","Confirmation_New_RAG"} and referenced_scheme:
+            if referenced_scheme not in st.session_state.scheme_names:
+                st.session_state.scheme_names = [referenced_scheme]
+                st.session_state.scheme_names_str = f"1. {referenced_scheme}"
+            logger.info(f"Maintaining stored scheme names: {st.session_state.scheme_names_str}")
+
+    def audio_task(final_text=None):
+        text_for_use = final_text if stream else generated_response
         step_local = time.time()
         hindi_audio_script = generate_hindi_audio_script(
-            generated_response,
+            text_for_use,
             user_info,
             rag_text or "",
         )
         record("audio_script", step_local)
 
+        if stream:
+            if intent == "Schemes_Know_Intent":
+                names = extract_scheme_names(text_for_use)
+                if names:
+                    st.session_state.scheme_names = [n for n in names]
+                    st.session_state.scheme_names_str = " ".join([f"{i+1}. {n}" for i, n in enumerate(names, 1)])
+                    logger.info(f"Stored scheme names from response: {st.session_state.scheme_names_str}")
+            elif intent in {"Specific_Scheme_Know_Intent", "Specific_Scheme_Apply_Intent", "Specific_Scheme_Eligibility_Intent","Contextual_Follow_Up","Confirmation_New_RAG"} and referenced_scheme:
+                if referenced_scheme not in st.session_state.scheme_names:
+                    st.session_state.scheme_names = [referenced_scheme]
+                    st.session_state.scheme_names_str = f"1. {referenced_scheme}"
+                logger.info(f"Maintaining stored scheme names: {st.session_state.scheme_names_str}")
+
         try:
             interaction_id = generate_interaction_id(query, datetime.utcnow())
             messages_to_save = [
                 {"role": "user", "content": query, "timestamp": datetime.utcnow(), "interaction_id": interaction_id},
-                {"role": "assistant", "content": generated_response, "timestamp": datetime.utcnow(), "interaction_id": interaction_id, "audio_script": hindi_audio_script},
+                {"role": "assistant", "content": text_for_use, "timestamp": datetime.utcnow(), "interaction_id": interaction_id, "audio_script": hindi_audio_script},
             ]
             if not any(
                 any(msg.get("interaction_id") == interaction_id for msg in conv["messages"])
@@ -1205,7 +1254,7 @@ def process_query(query, scheme_vector_store, dfl_vector_store, session_id, mobi
                 data_manager.save_conversation(session_id, mobile_number, messages_to_save)
                 record("save_conversation", step_db)
                 logger.info(
-                    f"Saved conversation for session {session_id}: {query} -> {generated_response} (Interaction ID: {interaction_id})"
+                    f"Saved conversation for session {session_id}: {query} -> {text_for_use} (Interaction ID: {interaction_id})"
                 )
             else:
                 logger.debug(
@@ -1217,4 +1266,6 @@ def process_query(query, scheme_vector_store, dfl_vector_store, session_id, mobi
         log_timings()
         return hindi_audio_script
 
+    if stream:
+        return gen_result, audio_task
     return generated_response, audio_task


### PR DESCRIPTION
## Summary
- implement `stream_tokens` to display streaming output
- add streaming mode to `generate_response` and `process_query`
- update app to stream welcome and chat responses

## Testing
- `python -m py_compile app.py msme_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68763ffcf340832e9c14ae1268702e7c