### PR TITLE
Fix DFL pinecone retrieval

### DIFF
--- a/msme_bot.py
+++ b/msme_bot.py
@@ -325,7 +325,7 @@ def get_scheme_response(
     return rag
 
 
-def get_dfl_response(query, vector_store, state="ALL_STATES", gender=None, business_category=None):
+def get_dfl_response(query, vector_store, state=None, gender=None, business_category=None):
     """Wrapper for DFL dataset retrieval with clearer logging."""
     logger.info("Querying DFL dataset")
     return get_rag_response(


### PR DESCRIPTION
## Summary
- disable state filter when querying the DFL index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879e16093f4832ea9fbdfb5efd41917