### PR TITLE
Remove scheme name extraction components

### DIFF
--- a/app.py
+++ b/app.py
@@ -169,10 +169,6 @@ if "rag_cache" not in st.session_state:
     st.session_state.rag_cache = {}
 if "dfl_rag_cache" not in st.session_state:
     st.session_state.dfl_rag_cache = {}
-if "scheme_names" not in st.session_state:
-    st.session_state.scheme_names = []
-if "scheme_names_str" not in st.session_state:
-    st.session_state.scheme_names_str = ""
 if "last_response_placeholder" not in st.session_state:
     st.session_state.last_response_placeholder = None
 


### PR DESCRIPTION
## Summary
- strip out scheme name extraction and resolution logic
- drop session state fields related to scheme names

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6879f2474a2c832e9a48e1d03877c06d